### PR TITLE
upgrade naar onderwijs-parent 2021.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>nl.topicus.onderwijs.parent</groupId>
 		<artifactId>onderwijs-parent-base</artifactId>
-		<version>2021.3.0</version>
+		<version>2021.3.1</version>
 		<relativePath/>
 	</parent>
 
 	<groupId>nl.topicus</groupId>
 	<artifactId>naming-kubernetes</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JBoss WildFly naming module for Kubernetes</name>


### PR DESCRIPTION
In de onderwijs-parent 2021.3.0 is de kubernetes:client geupgrade. Deze is incompatible met onze WF versie. Dit zorgt voor veel runtime errors omdat er een methode wordt aangeroepen die niet bestaat.

Die upgrade is terug gedraaid in 2021.3.1.